### PR TITLE
Enable io thread only

### DIFF
--- a/server/src/main/java/com/distkv/server/DstServer.java
+++ b/server/src/main/java/com/distkv/server/DstServer.java
@@ -45,6 +45,7 @@ public class DstServer {
   public DstServer(DistKVServerConfig config) {
     this.config = config;
     ServerConfig config1 = ServerConfig.builder()
+        .enableIOThreadOnly(true)
         .port(config.getPort())
         .build();
     drpcServer = new DrpcServer(config1);


### PR DESCRIPTION
1.Enable this flag to enable io thread only or disable io thread only.
2.Benchmark result of enable io thread only or disable io thread only:

True(enable io thread only):

``` bash
==========Benchmark Result================

API                          str.put()
t_count                      2
c_request                    10000
cost_avg                     995.5 ms
cost_min                     994 ms
cost_max                     997 ms
tps                          10.05 k/s
----------------------------------------------------------
t_count                      2
c_request                    100000
cost_avg                     4176.0 ms
cost_min                     4158 ms
cost_max                     4194 ms
tps                          23.95 k/s
===========================================
```



False(disable io thread only):

``` bash
============Benchmark Result===================
API                          str.put()
t_count                      2
c_request                    10000
cost_avg                     1255.5 ms
cost_min                     1218 ms
cost_max                     1293 ms
tps                          7.96 k/s
-----------------------------------------------------------------
t_count                      2
c_request                    100000
cost_avg                     4895.5 ms
cost_min                     4888 ms
cost_max                     4903 ms
tps                          20.43 k/s
==============================================
```







