### PR TITLE
Fix permission denied for creating symbolic link for distkv-server and distkv-cli.

### DIFF
--- a/scripts/install_distkv.sh
+++ b/scripts/install_distkv.sh
@@ -37,7 +37,7 @@ sudo cp $SERVER_JAR $SERVER_INSTALLING_DEST/distkv-server-0.1.3-SNAPSHOT-jar-wit
 sudo cp $CLIENT_JAR $CLIENT_INSTALLING_DEST/distkv-client-0.1.3-SNAPSHOT-jar-with-dependencies.jar
 
 # create soft link to binaries.
-ln -s $SERVER_INSTALLING_DEST/distkv-server /usr/local/bin/distkv-server
-ln -s $CLIENT_INSTALLING_DEST/distkv-cli /usr/local/bin/distkv-cli
+sudo ln -s $SERVER_INSTALLING_DEST/distkv-server /usr/local/bin/distkv-server
+sudo ln -s $CLIENT_INSTALLING_DEST/distkv-cli /usr/local/bin/distkv-cli
 
 echo "Wow~ Dst was installed successfully."


### PR DESCRIPTION
the symbolic link for distkv-server and distkv-cli can't be created because of permission denied. so use sudo to execute the command.