### PR TITLE
Support namespace filter for client to allow key conflicts

### DIFF
--- a/client/src/main/java/com/distkv/asyncclient/DefaultAsyncClient.java
+++ b/client/src/main/java/com/distkv/asyncclient/DefaultAsyncClient.java
@@ -33,10 +33,10 @@ public class DefaultAsyncClient implements DistkvAsyncClient {
     distkvRpcProxy.setInterfaceClass(DistkvService.class);
 
     stringProxy = new DistkvAsyncStringProxy(this, distkvRpcProxy.getService(rpcClient));
-    listProxy = new DistkvAsyncListProxy(distkvRpcProxy.getService(rpcClient));
-    setProxy = new DistkvAsyncSetProxy(distkvRpcProxy.getService(rpcClient));
-    dictProxy = new DistkvAsyncDictProxy(distkvRpcProxy.getService(rpcClient));
-    sortedListProxy = new DistkvAsyncSortedListProxy(distkvRpcProxy.getService(rpcClient));
+    listProxy = new DistkvAsyncListProxy(this, distkvRpcProxy.getService(rpcClient));
+    setProxy = new DistkvAsyncSetProxy(this, distkvRpcProxy.getService(rpcClient));
+    dictProxy = new DistkvAsyncDictProxy(this, distkvRpcProxy.getService(rpcClient));
+    sortedListProxy = new DistkvAsyncSortedListProxy(this, distkvRpcProxy.getService(rpcClient));
   }
 
   @Override

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 public abstract class DistkvAbstractAsyncProxy implements DistkvService {
 
-  private final static String DKV_NAMESPACE_PREFIX = "DKV_NSP";
+  private static final String DKV_NAMESPACE_PREFIX = "DKV_NSP";
 
   private List<Function<DistkvProtocol.DistkvRequest,
       DistkvProtocol.DistkvRequest>> filters = new ArrayList<>();

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
@@ -1,0 +1,49 @@
+package com.distkv.asyncclient;
+
+import com.distkv.rpc.protobuf.generated.DistkvProtocol;
+import com.distkv.rpc.service.DistkvService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+public abstract class DistkvAbstractAsyncProxy implements DistkvService {
+
+  private List<Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest>> filters = new ArrayList<>();
+
+  private DistkvService service;
+
+  public DistkvAbstractAsyncProxy(DistkvAsyncClient client, DistkvService service) {
+    this.service = service;
+
+    // The namespace filter.
+    appendFilter((DistkvProtocol.DistkvRequest request) -> {
+      if (client.getActivedNamespace() == null) {
+        return request;
+      }
+
+      final String key = String.format("DKV_NSP_{}_{}", client.getActivedNamespace(), request.getKey());
+      request = DistkvProtocol.DistkvRequest
+          .newBuilder()
+          .setKey(key)
+          .setRequestType(request.getRequestType())
+          .setRequest(request.getRequest())
+          .build();
+      return request;
+    });
+  }
+
+  private void appendFilter(Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest> filter) {
+    filters.add(filter);
+  }
+
+  public CompletableFuture<DistkvProtocol.DistkvResponse> call(DistkvProtocol.DistkvRequest request) {
+    DistkvProtocol.DistkvRequest localRequest = request;
+    for (Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest> filter : filters) {
+      localRequest = filter.apply(localRequest);
+    }
+    return service.call(localRequest);
+  }
+
+
+}

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAbstractAsyncProxy.java
@@ -9,7 +9,8 @@ import java.util.function.Function;
 
 public abstract class DistkvAbstractAsyncProxy implements DistkvService {
 
-  private List<Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest>> filters = new ArrayList<>();
+  private List<Function<DistkvProtocol.DistkvRequest,
+      DistkvProtocol.DistkvRequest>> filters = new ArrayList<>();
 
   private DistkvService service;
 
@@ -22,7 +23,8 @@ public abstract class DistkvAbstractAsyncProxy implements DistkvService {
         return request;
       }
 
-      final String key = String.format("DKV_NSP_{}_{}", client.getActivedNamespace(), request.getKey());
+      final String key = String.format(
+          "DKV_NSP_%s_%s", client.getActivedNamespace(), request.getKey());
       request = DistkvProtocol.DistkvRequest
           .newBuilder()
           .setKey(key)
@@ -33,11 +35,13 @@ public abstract class DistkvAbstractAsyncProxy implements DistkvService {
     });
   }
 
-  private void appendFilter(Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest> filter) {
+  private void appendFilter(
+      Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest> filter) {
     filters.add(filter);
   }
 
-  public CompletableFuture<DistkvProtocol.DistkvResponse> call(DistkvProtocol.DistkvRequest request) {
+  public CompletableFuture<DistkvProtocol.DistkvResponse> call(
+      DistkvProtocol.DistkvRequest request) {
     DistkvProtocol.DistkvRequest localRequest = request;
     for (Function<DistkvProtocol.DistkvRequest, DistkvProtocol.DistkvRequest> filter : filters) {
       localRequest = filter.apply(localRequest);

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncClient.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncClient.java
@@ -25,6 +25,13 @@ public interface DistkvAsyncClient {
   boolean disconnect();
 
   /**
+   * Active a namespace for this client.
+   */
+  void activeNamespace(String namespace);
+
+  String getActivedNamespace();
+
+  /**
    * Get the dst string proxy.
    *
    * @return The dst string proxy.

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncDictProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncDictProxy.java
@@ -9,12 +9,10 @@ import com.google.protobuf.Any;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-public class DistkvAsyncDictProxy {
+public class DistkvAsyncDictProxy extends DistkvAbstractAsyncProxy {
 
-  private DistkvService service;
-
-  public DistkvAsyncDictProxy(DistkvService service) {
-    this.service = service;
+  public DistkvAsyncDictProxy(DistkvAsyncClient client, DistkvService service) {
+    super(client, service);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> put(
@@ -28,7 +26,7 @@ public class DistkvAsyncDictProxy {
         .setRequestType(RequestType.DICT_PUT)
         .setRequest(Any.pack(dictPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(String key) {
@@ -36,7 +34,7 @@ public class DistkvAsyncDictProxy {
         .setKey(key)
         .setRequestType(RequestType.DICT_GET)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> getItem(
@@ -51,7 +49,7 @@ public class DistkvAsyncDictProxy {
         .setRequestType(RequestType.DICT_GET_ITEM)
         .setRequest(Any.pack(dictGetItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> popItem(String key, String itemKey) {
@@ -65,7 +63,7 @@ public class DistkvAsyncDictProxy {
         .setRequestType(RequestType.DICT_POP_ITEM)
         .setRequest(Any.pack(dictPopItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> putItem(
@@ -80,7 +78,7 @@ public class DistkvAsyncDictProxy {
         .setRequestType(RequestType.DICT_PUT_ITEM)
         .setRequest(Any.pack(dictPutItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> drop(String key) {
@@ -88,7 +86,7 @@ public class DistkvAsyncDictProxy {
         .setKey(key)
         .setRequestType(RequestType.DICT_DROP)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> removeItem(
@@ -103,6 +101,6 @@ public class DistkvAsyncDictProxy {
         .setRequestType(RequestType.DICT_REMOVE_ITEM)
         .setRequest(Any.pack(dictRemoveItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 }

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncListProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncListProxy.java
@@ -8,12 +8,10 @@ import com.google.protobuf.Any;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public class DistkvAsyncListProxy {
+public class DistkvAsyncListProxy extends DistkvAbstractAsyncProxy {
 
-  private DistkvService service;
-
-  public DistkvAsyncListProxy(DistkvService service) {
-    this.service = service;
+  public DistkvAsyncListProxy(DistkvAsyncClient client, DistkvService service) {
+    super(client, service);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> put(String key, List<String> values) {
@@ -26,7 +24,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_PUT)
         .setRequest(Any.pack(listPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(String key) {
@@ -39,7 +37,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_GET)
         .setRequest(Any.pack(listGetRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(String key, Integer index) {
@@ -53,7 +51,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_GET)
         .setRequest(Any.pack(listGetRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(
@@ -69,7 +67,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_GET)
         .setRequest(Any.pack(listGetRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> drop(String key) {
@@ -77,7 +75,7 @@ public class DistkvAsyncListProxy {
         .setKey(key)
         .setRequestType(RequestType.LIST_DROP)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> lput(String key, List<String> values) {
@@ -90,7 +88,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_LPUT)
         .setRequest(Any.pack(listLPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> rput(String key, List<String> values) {
@@ -103,7 +101,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_RPUT)
         .setRequest(Any.pack(listRPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> remove(String key, Integer index) {
@@ -117,7 +115,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_REMOVE)
         .setRequest(Any.pack(listRemoveRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> remove(
@@ -133,7 +131,7 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_REMOVE)
         .setRequest(Any.pack(listRemoveRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> mremove(
@@ -148,6 +146,6 @@ public class DistkvAsyncListProxy {
         .setRequestType(RequestType.LIST_MREMOVE)
         .setRequest(Any.pack(listMRemoveRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 }

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncSetProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncSetProxy.java
@@ -8,12 +8,10 @@ import com.google.protobuf.Any;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-public class DistkvAsyncSetProxy {
+public class DistkvAsyncSetProxy extends DistkvAbstractAsyncProxy {
 
-  private DistkvService service;
-
-  public DistkvAsyncSetProxy(DistkvService service) {
-    this.service = service;
+  public DistkvAsyncSetProxy(DistkvAsyncClient client, DistkvService service) {
+    super(client, service);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> put(String key, Set<String> values) {
@@ -26,7 +24,7 @@ public class DistkvAsyncSetProxy {
         .setRequestType(RequestType.SET_PUT)
         .setRequest(Any.pack(setPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(String key) {
@@ -34,7 +32,7 @@ public class DistkvAsyncSetProxy {
         .setKey(key)
         .setRequestType(RequestType.SET_GET)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> putItem(String key, String entity) {
@@ -47,7 +45,7 @@ public class DistkvAsyncSetProxy {
         .setRequestType(RequestType.SET_PUT_ITEM)
         .setRequest(Any.pack(setPutItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> removeItem(String key, String entity) {
@@ -60,7 +58,7 @@ public class DistkvAsyncSetProxy {
         .setRequestType(RequestType.SET_REMOVE_ITEM)
         .setRequest(Any.pack(setRemoveItemRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> drop(String key) {
@@ -68,7 +66,7 @@ public class DistkvAsyncSetProxy {
         .setKey(key)
         .setRequestType(RequestType.SET_DROP)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> exists(String key, String entity) {
@@ -80,6 +78,6 @@ public class DistkvAsyncSetProxy {
         .setRequestType(RequestType.SET_EXISTS)
         .setRequest(Any.pack(setExistsRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 }

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncSortedListProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncSortedListProxy.java
@@ -9,12 +9,10 @@ import com.google.protobuf.Any;
 import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;
 
-public class DistkvAsyncSortedListProxy {
+public class DistkvAsyncSortedListProxy extends DistkvAbstractAsyncProxy {
 
-  private DistkvService service;
-
-  public DistkvAsyncSortedListProxy(DistkvService service) {
-    this.service = service;
+  public DistkvAsyncSortedListProxy(DistkvAsyncClient client, DistkvService service) {
+    super(client, service);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> put(
@@ -37,7 +35,7 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_PUT)
         .setRequest(Any.pack(slistPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> incrScore(
@@ -53,7 +51,7 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_INCR_SCORE)
         .setRequest(Any.pack(slistInceScoreRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> top(String key, int topNum) {
@@ -68,7 +66,7 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_TOP)
         .setRequest(Any.pack(slistTopRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> drop(String key) {
@@ -76,7 +74,7 @@ public class DistkvAsyncSortedListProxy {
         .setKey(key)
         .setRequestType(RequestType.SORTED_LIST_DROP)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> removeMember(String key, String member) {
@@ -90,7 +88,7 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_REMOVE_MEMBER)
         .setRequest(Any.pack(slistRemoveMemberRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> putMember(
@@ -106,7 +104,7 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_PUT_MEMBER)
         .setRequest(Any.pack(slistPutMemberRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> getMember(
@@ -121,6 +119,6 @@ public class DistkvAsyncSortedListProxy {
         .setRequestType(RequestType.SORTED_LIST_GET_MEMBER)
         .setRequest(Any.pack(slistGetMemberRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 }

--- a/client/src/main/java/com/distkv/asyncclient/DistkvAsyncStringProxy.java
+++ b/client/src/main/java/com/distkv/asyncclient/DistkvAsyncStringProxy.java
@@ -7,12 +7,10 @@ import com.distkv.rpc.service.DistkvService;
 import com.google.protobuf.Any;
 import java.util.concurrent.CompletableFuture;
 
-public class DistkvAsyncStringProxy {
+public class DistkvAsyncStringProxy extends DistkvAbstractAsyncProxy {
 
-  private DistkvService service;
-
-  public DistkvAsyncStringProxy(DistkvService service) {
-    this.service = service;
+  public DistkvAsyncStringProxy(DistkvAsyncClient client, DistkvService service) {
+    super(client, service);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> put(
@@ -25,7 +23,7 @@ public class DistkvAsyncStringProxy {
         .setRequestType(RequestType.STR_PUT)
         .setRequest(Any.pack(strPutRequest))
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> get(String key) {
@@ -33,7 +31,7 @@ public class DistkvAsyncStringProxy {
         .setKey(key)
         .setRequestType(RequestType.STR_GET)
         .build();
-    return service.call(request);
+    return call(request);
   }
 
   public CompletableFuture<DistkvProtocol.DistkvResponse> drop(String key) {
@@ -41,6 +39,6 @@ public class DistkvAsyncStringProxy {
         .setKey(key)
         .setRequestType(RequestType.STR_DROP)
         .build();
-    return service.call(request);
+    return call(request);
   }
 }

--- a/client/src/main/java/com/distkv/namespace/NamespaceInterceptor.java
+++ b/client/src/main/java/com/distkv/namespace/NamespaceInterceptor.java
@@ -1,7 +1,7 @@
 package com.distkv.namespace;
 
 /**
- * This is a interceptor to intercept requests and resolve namespace
+ * This is an interceptor to intercept requests and resolve namespace
  * on the client side.
  */
 public class NamespaceInterceptor {

--- a/client/src/main/java/com/distkv/namespace/NamespaceInterceptor.java
+++ b/client/src/main/java/com/distkv/namespace/NamespaceInterceptor.java
@@ -1,0 +1,19 @@
+package com.distkv.namespace;
+
+/**
+ * This is a interceptor to intercept requests and resolve namespace
+ * on the client side.
+ */
+public class NamespaceInterceptor {
+
+  private String namespace;
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public  void active(String namespace) {
+    this.namespace = namespace;
+  }
+
+}

--- a/test/src/test/java/com/distkv/client/NamespaceTest.java
+++ b/test/src/test/java/com/distkv/client/NamespaceTest.java
@@ -1,0 +1,64 @@
+package com.distkv.client;
+
+import com.distkv.asyncclient.DistkvAsyncClient;
+import com.distkv.rpc.protobuf.generated.CommonProtocol;
+import com.distkv.rpc.protobuf.generated.DistkvProtocol;
+import com.distkv.rpc.protobuf.generated.StringProtocol;
+import com.distkv.supplier.BaseTestSupplier;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+public class NamespaceTest extends BaseTestSupplier {
+
+  @Test
+  public void testNamespaceEnabled()
+      throws ExecutionException, InterruptedException, InvalidProtocolBufferException {
+    DistkvAsyncClient client1 = newAsyncDistkvClient();
+    DistkvAsyncClient client2 = newAsyncDistkvClient();
+
+    client1.activeNamespace("a");
+    client2.activeNamespace("b");
+
+    CompletableFuture<DistkvProtocol.DistkvResponse> putFuture =
+        client1.strs().put("k1", "v1");
+    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
+    putFuture = client2.strs().put("k1", "v2");
+    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
+
+    CompletableFuture<DistkvProtocol.DistkvResponse> getFuture = client1.strs().get("k1");
+    String value = getFuture.get()
+        .getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
+    Assert.assertEquals(value, "v1");
+
+    getFuture = client2.strs().get("k1");
+    value = getFuture.get()
+        .getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
+    Assert.assertEquals(value, "v2");
+  }
+
+  @Test
+  public void testNamespaceDisabled()
+      throws ExecutionException, InterruptedException, InvalidProtocolBufferException  {
+    DistkvAsyncClient client1 = newAsyncDistkvClient();
+    DistkvAsyncClient client2 = newAsyncDistkvClient();
+
+    CompletableFuture<DistkvProtocol.DistkvResponse> putFuture =
+        client1.strs().put("k1", "v1");
+    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
+    putFuture = client2.strs().put("k1", "v2");
+    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
+
+    CompletableFuture<DistkvProtocol.DistkvResponse> getFuture = client1.strs().get("k1");
+    String value = getFuture.get()
+        .getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
+    Assert.assertEquals(value, "v2");
+
+    getFuture = client2.strs().get("k1");
+    value = getFuture.get().getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
+    Assert.assertEquals(value, "v2");
+  }
+
+}


### PR DESCRIPTION
This PR supports namespace concept for different clients to allow different clients write the same key with different values.

Implement the async client SDK part of #497