### PR TITLE
[Pine] Support `PineTopper` as a component of distkv ecosystem.

### DIFF
--- a/common/src/main/java/com/distkv/common/id/PineHandleId.java
+++ b/common/src/main/java/com/distkv/common/id/PineHandleId.java
@@ -1,0 +1,60 @@
+package com.distkv.common.id;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Random;
+
+public class PineHandleId implements Serializable {
+
+  private static final long serialVersionUID = -7937063292434146181L;
+
+  private static final int LENGTH = 16;
+
+  private int hashCodeCache = 0;
+
+  private byte[] data;
+
+  private PineHandleId(byte[] data) {
+    this.data = data;
+  }
+
+  public static PineHandleId fromRandom() {
+    byte[] data = new byte[LENGTH];
+    new Random().nextBytes(data);
+    return new PineHandleId(data);
+  }
+
+  public String hex() {
+    return DatatypeConverter.printHexBinary(data).toLowerCase();
+  }
+
+  @Override
+  public int hashCode() {
+    // Lazy evaluation.
+    if (hashCodeCache == 0) {
+      hashCodeCache = Arrays.hashCode(data);
+    }
+    return hashCodeCache;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+
+    if (!this.getClass().equals(obj.getClass())) {
+      return false;
+    }
+
+    PineHandleId r = (PineHandleId) obj;
+    return Arrays.equals(data, r.data);
+  }
+
+  @Override
+  public String toString() {
+    return hex();
+  }
+
+}

--- a/common/src/main/java/com/distkv/common/id/ShardId.java
+++ b/common/src/main/java/com/distkv/common/id/ShardId.java
@@ -10,7 +10,7 @@ public class ShardId implements Serializable {
   private static final long serialVersionUID = 6126218555756018827L;
 
   /**
-   * The index of the shard in the Dst cluster.
+   * The index of the shard in the Distkv cluster.
    */
   private int index;
 

--- a/common/src/test/java/com/distkv/common/id/IdTest.java
+++ b/common/src/test/java/com/distkv/common/id/IdTest.java
@@ -26,4 +26,8 @@ public class IdTest {
     Assert.assertEquals(id.getIndex(), 31000);
   }
 
+  @Test
+  public void testPineHandleId() {
+
+  }
 }

--- a/pine/pom.xml
+++ b/pine/pom.xml
@@ -11,5 +11,12 @@
 
     <artifactId>distkv-pine</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.distkv</groupId>
+            <artifactId>distkv-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/pine/src/main/java/com/distkv/pine/api/Pine.java
+++ b/pine/src/main/java/com/distkv/pine/api/Pine.java
@@ -3,18 +3,29 @@ package com.distkv.pine.api;
 import com.distkv.pine.components.PineTopper;
 import com.distkv.pine.runtime.PineRuntime;
 
+/**
+ * The API class of Pine.
+ */
 public class Pine {
 
+  /// The Pine runtime.
   private static PineRuntime runtime;
 
+  /**
+   * Initial the Pine.
+   */
   public static void init() {
     runtime = new PineRuntime();
     runtime.init();
   }
 
+  /**
+   * Shutdown the Pine.
+   */
   public static void shutdown() {
     if (runtime != null) {
       runtime.shutdown();
+      runtime = null;
     }
   }
 

--- a/pine/src/main/java/com/distkv/pine/api/Pine.java
+++ b/pine/src/main/java/com/distkv/pine/api/Pine.java
@@ -1,6 +1,6 @@
 package com.distkv.pine.api;
 
-import com.distkv.pine.components.PineTopper;
+import com.distkv.pine.components.topper.PineTopper;
 import com.distkv.pine.runtime.PineRuntime;
 
 /**
@@ -8,7 +8,9 @@ import com.distkv.pine.runtime.PineRuntime;
  */
 public class Pine {
 
-  /// The Pine runtime.
+  /**
+   * The Pine runtime.
+   */
   private static PineRuntime runtime;
 
   /**

--- a/pine/src/main/java/com/distkv/pine/api/Pine.java
+++ b/pine/src/main/java/com/distkv/pine/api/Pine.java
@@ -13,10 +13,12 @@ public class Pine {
 
   /**
    * Initial the Pine.
+   *
+   * @param address The address of distkv server to connect.
    */
-  public static void init() {
+  public static void init(String address) {
     runtime = new PineRuntime();
-    runtime.init();
+    runtime.init(address);
   }
 
   /**

--- a/pine/src/main/java/com/distkv/pine/components/AbstractPineHandle.java
+++ b/pine/src/main/java/com/distkv/pine/components/AbstractPineHandle.java
@@ -6,11 +6,11 @@ import com.distkv.common.id.PineHandleId;
  * The abstract class `PineHandle` is used to represent
  * a handle of the Pine component.
  */
-public abstract class PineHandle {
+public abstract class AbstractPineHandle {
 
   private PineHandleId handleId;
 
-  protected PineHandle() {
+  protected AbstractPineHandle() {
     handleId = PineHandleId.fromRandom();
   }
 

--- a/pine/src/main/java/com/distkv/pine/components/PineHandle.java
+++ b/pine/src/main/java/com/distkv/pine/components/PineHandle.java
@@ -1,0 +1,12 @@
+package com.distkv.pine.components;
+
+public abstract class PineHandle {
+
+  private PineHandleId handleId;
+
+  protected String getKey() {
+    return String.format("%s_%s", getComponentType(), handleId.toString());
+  }
+
+  protected abstract String getComponentType();
+}

--- a/pine/src/main/java/com/distkv/pine/components/PineHandle.java
+++ b/pine/src/main/java/com/distkv/pine/components/PineHandle.java
@@ -3,8 +3,8 @@ package com.distkv.pine.components;
 import com.distkv.common.id.PineHandleId;
 
 /**
- * The abstract class `PineHandle` is used to represent a handle
- * of the Pine component.
+ * The abstract class `PineHandle` is used to represent
+ * a handle of the Pine component.
  */
 public abstract class PineHandle {
 
@@ -15,6 +15,8 @@ public abstract class PineHandle {
   }
 
   protected String getKey() {
+    /// Note that the key of Pine component is used a prefix that is the component type.
+    /// And the suffix of the key the handle id of the component.
     return String.format("%s_%s", getComponentType(), handleId.hex());
   }
 

--- a/pine/src/main/java/com/distkv/pine/components/PineHandle.java
+++ b/pine/src/main/java/com/distkv/pine/components/PineHandle.java
@@ -1,12 +1,23 @@
 package com.distkv.pine.components;
 
+import com.distkv.common.id.PineHandleId;
+
+/**
+ * The abstract class `PineHandle` is used to represent a handle
+ * of the Pine component.
+ */
 public abstract class PineHandle {
 
   private PineHandleId handleId;
 
+  protected PineHandle() {
+    handleId = PineHandleId.fromRandom();
+  }
+
   protected String getKey() {
-    return String.format("%s_%s", getComponentType(), handleId.toString());
+    return String.format("%s_%s", getComponentType(), handleId.hex());
   }
 
   protected abstract String getComponentType();
+
 }

--- a/pine/src/main/java/com/distkv/pine/components/PineTopper.java
+++ b/pine/src/main/java/com/distkv/pine/components/PineTopper.java
@@ -1,4 +1,34 @@
 package com.distkv.pine.components;
 
+import javafx.util.Pair;
+import java.util.List;
+
+/**
+ * The `PineTopper` component is used to do a xxxx.
+ */
 public interface PineTopper {
+
+  /**
+   * Add a member to this topper.
+   *
+   * @param memberName The name of the member that will be added.
+   * @param memberScore The score of the member.
+   */
+  public void addMember(String memberName, int memberScore);
+
+  /**
+   * Remove a member from this topper.
+   *
+   * @param memberName The name of the member that will be removed.
+   */
+  public void removeMember(String memberName);
+
+  /**
+   * Get the topper members.
+   *
+   * @param num The top number that will be returned.
+   */
+  // TODO(qwang): The `Pair` should be refined with our implementation.
+  public List<Pair<String, Integer>> top(int num);
+
 }

--- a/pine/src/main/java/com/distkv/pine/components/PineTopperImpl.java
+++ b/pine/src/main/java/com/distkv/pine/components/PineTopperImpl.java
@@ -1,5 +1,48 @@
 package com.distkv.pine.components;
 
-public class PineTopperImpl implements PineTopper {
+import com.distkv.client.DistkvClient;
+import com.distkv.common.entity.sortedList.SortedListEntity;
+import com.google.protobuf.InvalidProtocolBufferException;
+import javafx.util.Pair;
+import java.util.LinkedList;
+import java.util.List;
+
+public class PineTopperImpl  extends PineHandle implements PineTopper {
+
+
+  private static final String COMPONENT_TYPE = "TOPPER";
+
+  private DistkvClient distkvClient;
+
+  public PineTopperImpl(DistkvClient distkvClient) {
+    this.distkvClient = distkvClient;
+    // Construct an empty sorted-list to the store.
+    distkvClient.sortedLists().put(getKey(), new LinkedList<>());
+  }
+
+  @Override
+  public void addMember(String memberName, int memberScore) {
+    distkvClient.sortedLists().putMember(getKey(), new SortedListEntity(memberName, memberScore));
+  }
+
+  public void removeMember(String memberName) {
+    distkvClient.sortedLists().removeMember(getKey(), memberName);
+  }
+
+  public List<Pair<String, Integer>> top(int num) {
+    try {
+      LinkedList<SortedListEntity> result = distkvClient.sortedLists().top(getKey(), num);
+      // Covert the result type.
+
+    } catch (InvalidProtocolBufferException e) {
+      // TODO(qwang): Refine this.
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected String getComponentType() {
+    return COMPONENT_TYPE;
+  }
 
 }

--- a/pine/src/main/java/com/distkv/pine/components/topper/PineTopper.java
+++ b/pine/src/main/java/com/distkv/pine/components/topper/PineTopper.java
@@ -1,10 +1,10 @@
-package com.distkv.pine.components;
+package com.distkv.pine.components.topper;
 
-import javafx.util.Pair;
+import com.distkv.common.DistkvTuple;
 import java.util.List;
 
 /**
- * The `PineTopper` component is used to do a xxxx.
+ * The `PineTopper` component is used as a ranking list.
  */
 public interface PineTopper {
 
@@ -24,11 +24,18 @@ public interface PineTopper {
   public void removeMember(String memberName);
 
   /**
+   * Get the member of the given name.
+   *
+   * @param memberName The name of the member that will be find.
+   */
+  public TopperMember getMember(String memberName);
+
+  /**
    * Get the topper members.
    *
    * @param num The top number that will be returned.
    */
   // TODO(qwang): The `Pair` should be refined with our implementation.
-  public List<Pair<String, Integer>> top(int num);
+  public List<DistkvTuple<String, Integer>> top(int num);
 
 }

--- a/pine/src/main/java/com/distkv/pine/components/topper/PineTopperImpl.java
+++ b/pine/src/main/java/com/distkv/pine/components/topper/PineTopperImpl.java
@@ -3,13 +3,13 @@ package com.distkv.pine.components.topper;
 import com.distkv.client.DistkvClient;
 import com.distkv.common.DistkvTuple;
 import com.distkv.common.entity.sortedList.SortedListEntity;
-import com.distkv.pine.components.PineHandle;
+import com.distkv.pine.components.AbstractPineHandle;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-public class PineTopperImpl  extends PineHandle implements PineTopper {
+public class PineTopperImpl  extends AbstractPineHandle implements PineTopper {
 
   private static final String COMPONENT_TYPE = "TOPPER";
 

--- a/pine/src/main/java/com/distkv/pine/components/topper/PineTopperImpl.java
+++ b/pine/src/main/java/com/distkv/pine/components/topper/PineTopperImpl.java
@@ -54,7 +54,8 @@ public class PineTopperImpl  extends PineHandle implements PineTopper {
   @Override
   public TopperMember getMember(String memberName) {
     try {
-      DistkvTuple<Integer, Integer> result = distkvClient.sortedLists().getMember(getKey(), memberName);
+      DistkvTuple<Integer, Integer> result = distkvClient.sortedLists().getMember(
+          getKey(), memberName);
       return new TopperMember(memberName, result.getSecond(), result.getFirst());
     } catch (InvalidProtocolBufferException e) {
       // TODO(qwang): Refine this exception.

--- a/pine/src/main/java/com/distkv/pine/components/topper/TopperMember.java
+++ b/pine/src/main/java/com/distkv/pine/components/topper/TopperMember.java
@@ -1,0 +1,33 @@
+package com.distkv.pine.components.topper;
+
+
+/**
+ * The class represents a member of Topper.
+ */
+public class TopperMember {
+  private String name;
+
+  private int rankingNum;
+
+  private int score;
+
+  public TopperMember(String name, int rankingNum, int score) {
+    this.name = name;
+    this.rankingNum = rankingNum;
+    this.score = score;
+  }
+
+
+  public int getRankingNum() {
+    return rankingNum;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getScore() {
+    return score;
+  }
+
+}

--- a/pine/src/main/java/com/distkv/pine/components/topper/TopperMember.java
+++ b/pine/src/main/java/com/distkv/pine/components/topper/TopperMember.java
@@ -2,7 +2,7 @@ package com.distkv.pine.components.topper;
 
 
 /**
- * The class represents a member of Topper.
+ * The class represents a handle of a Topper member.
  */
 public class TopperMember {
   private String name;
@@ -16,6 +16,7 @@ public class TopperMember {
     this.rankingNum = rankingNum;
     this.score = score;
   }
+
 
 
   public int getRankingNum() {

--- a/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
+++ b/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
@@ -1,15 +1,20 @@
 package com.distkv.pine.runtime;
 
+import com.distkv.client.DefaultDistkvClient;
 import com.distkv.client.DistkvClient;
 import com.distkv.pine.components.PineTopper;
 import com.distkv.pine.components.PineTopperImpl;
 
 public class PineRuntime {
 
-  private DistkvClient client;
 
-  public void init() {
+  /**
+   * The distkv sync client.
+   */
+  private DistkvClient distkvClient;
 
+  public void init(String address) {
+    distkvClient = new DefaultDistkvClient(address);
   }
 
   public void shutdown() {

--- a/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
+++ b/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
@@ -1,9 +1,12 @@
 package com.distkv.pine.runtime;
 
+import com.distkv.client.DistkvClient;
 import com.distkv.pine.components.PineTopper;
 import com.distkv.pine.components.PineTopperImpl;
 
 public class PineRuntime {
+
+  private DistkvClient client;
 
   public void init() {
 

--- a/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
+++ b/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
@@ -2,8 +2,8 @@ package com.distkv.pine.runtime;
 
 import com.distkv.client.DefaultDistkvClient;
 import com.distkv.client.DistkvClient;
-import com.distkv.pine.components.PineTopper;
-import com.distkv.pine.components.PineTopperImpl;
+import com.distkv.pine.components.topper.PineTopper;
+import com.distkv.pine.components.topper.PineTopperImpl;
 
 public class PineRuntime {
 

--- a/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
+++ b/pine/src/main/java/com/distkv/pine/runtime/PineRuntime.java
@@ -22,7 +22,7 @@ public class PineRuntime {
   }
 
   public PineTopper newTopper() {
-    return new PineTopperImpl();
+    return new PineTopperImpl(distkvClient);
   }
 
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>com.distkv</groupId>
+            <artifactId>distkv-pine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.distkv</groupId>
             <artifactId>distkv-server</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/src/test/java/com/distkv/pine/TopperTest.java
+++ b/test/src/test/java/com/distkv/pine/TopperTest.java
@@ -1,0 +1,64 @@
+package com.distkv.pine;
+
+import com.distkv.common.DistkvTuple;
+import com.distkv.pine.api.Pine;
+import com.distkv.pine.components.topper.PineTopper;
+import com.distkv.supplier.BaseTestSupplier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.util.List;
+
+public class TopperTest extends BaseTestSupplier {
+
+  @Test
+  public void testTopper() {
+    Pine.init(listeningAddress);
+    PineTopper topper = Pine.newTopper();
+    topper.addMember("Bob", 80);
+    topper.addMember("Allen", 100);
+    topper.addMember("Lisa", 90);
+
+    // Assert top1.
+    {
+      List<DistkvTuple<String, Integer>> items = topper.top(1);
+      Assert.assertEquals(items.size(), 1);
+      Assert.assertEquals(items.get(0).getFirst(), "Allen");
+      Assert.assertEquals((int) items.get(0).getSecond(), 100);
+    }
+
+    {
+      // Assert top2.
+      List<DistkvTuple<String, Integer>> items = topper.top(2);
+      Assert.assertEquals(items.size(), 2);
+      Assert.assertEquals(items.get(0).getFirst(), "Allen");
+      Assert.assertEquals((int) items.get(0).getSecond(), 100);
+      Assert.assertEquals(items.get(1).getFirst(), "Lisa");
+      Assert.assertEquals((int) items.get(1).getSecond(), 90);
+    }
+
+    {
+      // Assert top3.
+      List<DistkvTuple<String, Integer>> items = topper.top(3);
+      Assert.assertEquals(items.size(), 3);
+      Assert.assertEquals(items.get(0).getFirst(), "Allen");
+      Assert.assertEquals((int) items.get(0).getSecond(), 100);
+      Assert.assertEquals(items.get(1).getFirst(), "Lisa");
+      Assert.assertEquals((int) items.get(1).getSecond(), 90);
+      Assert.assertEquals(items.get(2).getFirst(), "Bob");
+      Assert.assertEquals((int) items.get(2).getSecond(), 80);
+    }
+
+    {
+      // Assert get member.
+      Assert.assertEquals(topper.getMember("Allen").getScore(), 100);
+      Assert.assertEquals(topper.getMember("Lisa").getScore(), 90);
+      Assert.assertEquals(topper.getMember("Bob").getScore(), 80);
+
+      Assert.assertEquals(topper.getMember("Allen").getRankingNum(), 1);
+      Assert.assertEquals(topper.getMember("Lisa").getRankingNum(), 2);
+      Assert.assertEquals(topper.getMember("Bob").getRankingNum(), 3);
+    }
+    Pine.shutdown();
+  }
+
+}

--- a/test/src/test/java/com/distkv/supplier/BaseTestSupplier.java
+++ b/test/src/test/java/com/distkv/supplier/BaseTestSupplier.java
@@ -20,6 +20,8 @@ public class BaseTestSupplier {
 
   protected int rpcServerPort = -1;
 
+  protected String listeningAddress;
+
   @BeforeMethod
   public void setupBase(Method method) throws InterruptedException {
     LOGGER.info(String.format("\n==================== Running the test method: %s.%s",
@@ -28,6 +30,7 @@ public class BaseTestSupplier {
         method.getDeclaringClass(), method.getName()));
     rpcServerPort = (Math.abs(new Random().nextInt() % 10000)) + 10000;
     TestUtil.startRpcServer(rpcServerPort);
+    listeningAddress = String.format("distkv://127.0.0.1:%d", rpcServerPort);
     TimeUnit.SECONDS.sleep(1);
   }
 


### PR DESCRIPTION
### Introduction
As discussed before, we'd like to support a feature named `Pine` as the ecosystem of Distkv. The `Pine` is a set of useful components for Web application that helps Web developer develop simpley.

This PR supports the `PineTopper` component as the ranking list.

### Usage of this PR
The usage or API of `PineTopper` looks like:
```Java
try {
  Pine.init();
  PineTopper topper = Pine.newTopper();
  topper.addMember("Bob", 80);
  topper.addMember("Allen", 90);
  topper.addMember("Lisa", 100);

  // This didn't implement in this PR now.
  topper.getMember("Bob").incr(20);

  topper.top(2); // will return the top 2 items: Bob, 110         Lisa 100
 
} catch (Exception e) {

} finally {
 Pine.shutdown();
}

```

The related issue is #279 