### PR TITLE
[StorageEngine] Put all data into one map

### DIFF
--- a/core/src/main/java/com/distkv/core/KVStoreImpl.java
+++ b/core/src/main/java/com/distkv/core/KVStoreImpl.java
@@ -15,25 +15,32 @@ import com.distkv.core.concepts.DistkvSortedListsImpl;
 
 public class KVStoreImpl implements KVStore {
 
+  // The store proxy of string concept.
   private DistkvStringsImpl strs;
 
-  private DistkvListsImpl lists;
-
-  private DistkvSetsImpl sets;
-
-  private DistkvDictsImpl dicts;
-
-  private DistkvSortedLists sortedLists;
-
+  // The store proxy of int concept.
   private DistkvInts ints;
 
+  // The store proxy of list concept.
+  private DistkvListsImpl lists;
+
+  // The store proxy of set concept.
+  private DistkvSetsImpl sets;
+
+  // The store proxy of dict concept.
+  private DistkvDictsImpl dicts;
+
+  // The store proxy of sorted list concept.
+  private DistkvSortedLists sortedLists;
+
   public KVStoreImpl() {
-    this.strs = new DistkvStringsImpl();
-    this.lists = new DistkvListsImpl();
-    this.sets = new DistkvSetsImpl();
-    this.dicts = new DistkvDictsImpl();
-    this.sortedLists = new DistkvSortedListsImpl();
-    this.ints = new DistkvIntsImpl();
+    DistkvMapInterface<String, Object> distkvKeyValueMap = new DistkvHashMapImpl<>();
+    this.strs = new DistkvStringsImpl(distkvKeyValueMap);
+    this.lists = new DistkvListsImpl(distkvKeyValueMap);
+    this.sets = new DistkvSetsImpl(distkvKeyValueMap);
+    this.dicts = new DistkvDictsImpl(distkvKeyValueMap);
+    this.sortedLists = new DistkvSortedListsImpl(distkvKeyValueMap);
+    this.ints = new DistkvIntsImpl(distkvKeyValueMap);
   }
 
   @Override

--- a/core/src/main/java/com/distkv/core/concepts/DistkvConcepts.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvConcepts.java
@@ -2,23 +2,28 @@ package com.distkv.core.concepts;
 
 import com.distkv.common.exception.KeyNotFoundException;
 import com.distkv.common.utils.Status;
-import com.distkv.core.DistkvHashMapImpl;
 import com.distkv.core.DistkvMapInterface;
 
 public abstract class DistkvConcepts<T> {
 
-  protected DistkvMapInterface<String, T> distkvKeyValueMap = new DistkvHashMapImpl<>();
+  // The Reference of the key value map.
+  protected DistkvMapInterface<String, Object> distkvKeyValueMap;
+
+  protected DistkvConcepts(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    this.distkvKeyValueMap = distkvKeyValueMap;
+  }
 
   public void put(String key, T value) {
     distkvKeyValueMap.put(key, value);
   }
 
+  @SuppressWarnings("unchecked")
   public T get(String key) {
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
 
-    return distkvKeyValueMap.get(key);
+    return (T) distkvKeyValueMap.get(key);
   }
 
   public Status drop(String key) {

--- a/core/src/main/java/com/distkv/core/concepts/DistkvConcepts.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvConcepts.java
@@ -1,5 +1,6 @@
 package com.distkv.core.concepts;
 
+import com.distkv.common.exception.DistkvKeyDuplicatedException;
 import com.distkv.common.exception.KeyNotFoundException;
 import com.distkv.common.utils.Status;
 import com.distkv.core.DistkvMapInterface;
@@ -14,6 +15,9 @@ public abstract class DistkvConcepts<T> {
   }
 
   public void put(String key, T value) {
+    if (distkvKeyValueMap.containsKey(key)) {
+      throw new DistkvKeyDuplicatedException(key);
+    }
     distkvKeyValueMap.put(key, value);
   }
 

--- a/core/src/main/java/com/distkv/core/concepts/DistkvDictsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvDictsImpl.java
@@ -1,7 +1,11 @@
 package com.distkv.core.concepts;
 
+import com.distkv.core.DistkvMapInterface;
+
 import java.util.Map;
 
 public class DistkvDictsImpl extends DistkvConcepts<Map<String, String>> implements DistkvDicts {
-
+  public DistkvDictsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
+  }
 }

--- a/core/src/main/java/com/distkv/core/concepts/DistkvIntsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvIntsImpl.java
@@ -1,12 +1,18 @@
 package com.distkv.core.concepts;
 
+import com.distkv.core.DistkvMapInterface;
+
 public class DistkvIntsImpl
     extends DistkvConcepts<Integer>
     implements DistkvInts {
 
+  public DistkvIntsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
+  }
+
   @Override
   public void incr(String key, int delta) {
-    Integer oldValue = super.distkvKeyValueMap.get(key);
+    Integer oldValue = get(key);
     oldValue += delta;
     super.distkvKeyValueMap.put(key, oldValue);
   }

--- a/core/src/main/java/com/distkv/core/concepts/DistkvListsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvListsImpl.java
@@ -3,6 +3,7 @@ package com.distkv.core.concepts;
 import com.distkv.common.exception.DistkvListIndexOutOfBoundsException;
 import com.distkv.common.exception.KeyNotFoundException;
 import com.distkv.common.utils.Status;
+import com.distkv.core.DistkvMapInterface;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -10,11 +11,16 @@ import java.util.Set;
 
 public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implements DistkvLists {
 
+  public DistkvListsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
+  }
+
+
 
   @Override
   public String get(String key, int index) throws KeyNotFoundException, IndexOutOfBoundsException {
     try {
-      final List<String> list = this.distkvKeyValueMap.get(key);
+      final List<String> list = get(key);
       return list.get(index);
     } catch (NullPointerException e) {
       throw new KeyNotFoundException(key);
@@ -27,7 +33,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
   public List<String> get(String key, int from, int end)
       throws KeyNotFoundException, IndexOutOfBoundsException {
     try {
-      final List<String> list = this.distkvKeyValueMap.get(key);
+      final List<String> list = get(key);
       return list.subList(from, end);
     } catch (NullPointerException e) {
       throw new KeyNotFoundException(key);
@@ -41,7 +47,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
     if (!this.distkvKeyValueMap.containsKey(key)) {
       return Status.KEY_NOT_FOUND;
     }
-    this.distkvKeyValueMap.get(key).addAll(0, value);
+    get(key).addAll(0, value);
     return Status.OK;
   }
 
@@ -50,7 +56,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
     if (!this.distkvKeyValueMap.containsKey(key)) {
       return Status.KEY_NOT_FOUND;
     }
-    this.distkvKeyValueMap.get(key).addAll(value);
+    get(key).addAll(value);
     return Status.OK;
   }
 
@@ -58,7 +64,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
   public Status remove(String key, int index)
           throws KeyNotFoundException, DistkvListIndexOutOfBoundsException {
     try {
-      List<String> list = this.distkvKeyValueMap.get(key);
+      List<String> list = get(key);
       list.remove(index);
       return Status.OK;
     } catch (NullPointerException e) {
@@ -72,7 +78,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
   public Status remove(String key, int from, int end)
           throws KeyNotFoundException, DistkvListIndexOutOfBoundsException {
     try {
-      List<String> list = this.distkvKeyValueMap.get(key);
+      List<String> list = get(key);
       list.subList(from, end).clear();
       return Status.OK;
     } catch (NullPointerException e) {
@@ -85,7 +91,7 @@ public class DistkvListsImpl extends DistkvConcepts<ArrayList<String>> implement
   @Override
   public Status mremove(String key, List<Integer> indexes)
           throws KeyNotFoundException, DistkvListIndexOutOfBoundsException {
-    final List<String> list = this.distkvKeyValueMap.get(key);
+    final List<String> list = get(key);
     if (list == null) {
       throw new KeyNotFoundException(key);
     }

--- a/core/src/main/java/com/distkv/core/concepts/DistkvSetsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvSetsImpl.java
@@ -3,11 +3,14 @@ package com.distkv.core.concepts;
 import com.distkv.common.exception.KeyNotFoundException;
 import com.distkv.common.exception.SetItemNotFoundException;
 import com.distkv.common.utils.Status;
+import com.distkv.core.DistkvMapInterface;
+
 import java.util.Set;
 
 public class DistkvSetsImpl extends DistkvConcepts<Set<String>> implements DistkvSets {
 
-  public DistkvSetsImpl() {
+  public DistkvSetsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
   }
 
   @Override
@@ -16,7 +19,7 @@ public class DistkvSetsImpl extends DistkvConcepts<Set<String>> implements Distk
       throw new KeyNotFoundException(key);
     }
 
-    distkvKeyValueMap.get(key).add(itemValue);
+    get(key).add(itemValue);
   }
 
   @Override
@@ -25,10 +28,10 @@ public class DistkvSetsImpl extends DistkvConcepts<Set<String>> implements Distk
       return Status.KEY_NOT_FOUND;
     }
 
-    if (!distkvKeyValueMap.get(key).contains(itemValue)) {
+    if (!get(key).contains(itemValue)) {
       throw new SetItemNotFoundException(key, itemValue);
     }
-    distkvKeyValueMap.get(key).remove(itemValue);
+    get(key).remove(itemValue);
     return Status.OK;
   }
 
@@ -38,7 +41,7 @@ public class DistkvSetsImpl extends DistkvConcepts<Set<String>> implements Distk
       throw new KeyNotFoundException(key);
     }
 
-    return distkvKeyValueMap.get(key).contains(value);
+    return get(key).contains(value);
   }
 
 }

--- a/core/src/main/java/com/distkv/core/concepts/DistkvSortedListsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvSortedListsImpl.java
@@ -8,6 +8,7 @@ import com.distkv.common.exception.SortedListIncrScoreOutOfRangeException;
 import com.distkv.common.exception.SortedListMemberNotFoundException;
 import com.distkv.common.exception.SortedListTopNumIsNonNegativeException;
 import com.distkv.common.entity.sortedList.SortedListEntity;
+import com.distkv.core.DistkvMapInterface;
 import com.distkv.core.struct.slist.SortedList;
 import com.distkv.core.struct.slist.SortedListLinkedImpl;
 
@@ -17,8 +18,9 @@ import java.util.LinkedList;
 public class DistkvSortedListsImpl
     extends DistkvConcepts<SortedList>
     implements DistkvSortedLists {
-  public DistkvSortedListsImpl() {
 
+  public DistkvSortedListsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
   }
 
   @Override
@@ -38,7 +40,7 @@ public class DistkvSortedListsImpl
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
-    final SortedList sortedList = distkvKeyValueMap.get(key);
+    final SortedList sortedList = get(key);
     sortedList.putItem(item);
   }
 
@@ -47,7 +49,7 @@ public class DistkvSortedListsImpl
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
-    final SortedList sortedList = distkvKeyValueMap.get(key);
+    final SortedList sortedList = get(key);
     final boolean isFound = sortedList.removeItem(member);
     if (!isFound) {
       throw new SortedListMemberNotFoundException(key);
@@ -59,7 +61,7 @@ public class DistkvSortedListsImpl
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
-    final SortedList sortedList = distkvKeyValueMap.get(key);
+    final SortedList sortedList = get(key);
     final int resultByIncrScore = sortedList.incrScore(member, delta);
     if (0 == resultByIncrScore) {
       throw new SortedListMemberNotFoundException(key);
@@ -73,7 +75,7 @@ public class DistkvSortedListsImpl
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
-    final SortedList sortedList = distkvKeyValueMap.get(key);
+    final SortedList sortedList = get(key);
     if (topNum > sortedList.size()) {
       topNum = sortedList.size();
     }
@@ -88,7 +90,7 @@ public class DistkvSortedListsImpl
     if (!distkvKeyValueMap.containsKey(key)) {
       throw new KeyNotFoundException(key);
     }
-    final SortedList sortedLists = distkvKeyValueMap.get(key);
+    final SortedList sortedLists = get(key);
     DistkvTuple<Integer, Integer> result = sortedLists.getItem(member);
     if (null == result) {
       throw new SortedListMemberNotFoundException(key);

--- a/core/src/main/java/com/distkv/core/concepts/DistkvStringsImpl.java
+++ b/core/src/main/java/com/distkv/core/concepts/DistkvStringsImpl.java
@@ -1,6 +1,11 @@
 package com.distkv.core.concepts;
 
 
+import com.distkv.core.DistkvMapInterface;
+
 public class DistkvStringsImpl extends DistkvConcepts<String> implements DistkvStrings {
 
+  public DistkvStringsImpl(DistkvMapInterface<String, Object> distkvKeyValueMap) {
+    super(distkvKeyValueMap);
+  }
 }

--- a/rpc/src/main/proto/common_pb.proto
+++ b/rpc/src/main/proto/common_pb.proto
@@ -22,6 +22,8 @@ enum Status {
     SYNC_ERROR = 8;
     // The key of the set is not found.
     SET_ITEM_NOT_FOUND = 9;
+
+    DUPLICATED_KEY = 10;
 };
 
 // Drop the k-v pair by the given key.

--- a/test/src/test/java/com/distkv/client/NamespaceTest.java
+++ b/test/src/test/java/com/distkv/client/NamespaceTest.java
@@ -41,24 +41,17 @@ public class NamespaceTest extends BaseTestSupplier {
 
   @Test
   public void testNamespaceDisabled()
-      throws ExecutionException, InterruptedException, InvalidProtocolBufferException  {
+      throws ExecutionException, InterruptedException  {
     DistkvAsyncClient client1 = newAsyncDistkvClient();
     DistkvAsyncClient client2 = newAsyncDistkvClient();
 
     CompletableFuture<DistkvProtocol.DistkvResponse> putFuture =
         client1.strs().put("k1", "v1");
-    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
-    putFuture = client2.strs().put("k1", "v2");
-    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
 
-    CompletableFuture<DistkvProtocol.DistkvResponse> getFuture = client1.strs().get("k1");
-    String value = getFuture.get()
-        .getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
-    Assert.assertEquals(value, "v2");
-
-    getFuture = client2.strs().get("k1");
-    value = getFuture.get().getResponse().unpack(StringProtocol.StrGetResponse.class).getValue();
-    Assert.assertEquals(value, "v2");
+    Assert.assertEquals(CommonProtocol.Status.OK, putFuture.get().getStatus());
+    final CompletableFuture<DistkvProtocol.DistkvResponse> putFuture2 =
+        client2.strs().put("k1", "v2");
+    Assert.assertEquals(CommonProtocol.Status.DUPLICATED_KEY, putFuture2.get().getStatus());
   }
 
 

--- a/test/src/test/java/com/distkv/client/StringProxyTest.java
+++ b/test/src/test/java/com/distkv/client/StringProxyTest.java
@@ -38,29 +38,29 @@ public class StringProxyTest extends BaseTestSupplier {
     DistkvClient client = newDistkvClient();
 
     // string
-    client.strs().put("k1", "v1");
-    Assert.assertEquals("v1", client.strs().get("k1"));
+    client.strs().put("str_k1", "v1");
+    Assert.assertEquals("v1", client.strs().get("str_k1"));
 
     // list
-    client.lists().put("k1", ImmutableList.of("v1", "v2", "v3"));
-    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client.lists().get("k1"));
+    client.lists().put("list_k1", ImmutableList.of("v1", "v2", "v3"));
+    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client.lists().get("list_k1"));
     Assert.assertEquals(ImmutableList.of("v2", "v3"),
-        client.lists().get("k1", 1, 3));
+        client.lists().get("list_k1", 1, 3));
 
     // set
     Set<String> set = ImmutableSet.of("v1", "v2", "v3");
-    client.sets().put("k1", set);
-    Assert.assertEquals(set, client.sets().get("k1"));
+    client.sets().put("set_k1", set);
+    Assert.assertEquals(set, client.sets().get("set_k1"));
     client.disconnect();
   }
 
   @Test
   public void testExpireStr() throws InterruptedException {
     DistkvClient client = newDistkvClient();
-    client.strs().put("k1", "v1");
-    client.strs().expire("k1", 1);
+    client.strs().put("expired_k1", "v1");
+    client.strs().expire("expired_k1", 1);
     Thread.sleep(3000);
-    Assert.assertThrows(KeyNotFoundException.class, () -> client.strs().get("k1"));
+    Assert.assertThrows(KeyNotFoundException.class, () -> client.strs().get("expired_k1"));
     client.disconnect();
   }
 

--- a/test/src/test/java/com/distkv/client/masterslavesync/TestMasterSyncToSlaves.java
+++ b/test/src/test/java/com/distkv/client/masterslavesync/TestMasterSyncToSlaves.java
@@ -49,34 +49,34 @@ public class TestMasterSyncToSlaves {
 
   public void testStrPut(DistkvClient client0, DistkvClient client1)
       throws InvalidProtocolBufferException {
-    client0.strs().put("k1", "v1");
-    Assert.assertEquals("v1", client0.strs().get("k1"));
-    Assert.assertEquals("v1", client1.strs().get("k1"));
+    client0.strs().put("str_k1", "v1");
+    Assert.assertEquals("v1", client0.strs().get("str_k1"));
+    Assert.assertEquals("v1", client1.strs().get("str_k1"));
   }
 
 
   public void testListPut(DistkvClient client0, DistkvClient client1) {
 
-    client0.lists().put("k1", ImmutableList.of("v1", "v2", "v3"));
-    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client0.lists().get("k1"));
+    client0.lists().put("list_k1", ImmutableList.of("v1", "v2", "v3"));
+    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client0.lists().get("list_k1"));
     Assert.assertEquals(ImmutableList.of("v2", "v3"),
-        client0.lists().get("k1", 1, 3));
+        client0.lists().get("list_k1", 1, 3));
 
-    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client1.lists().get("k1"));
+    Assert.assertEquals(ImmutableList.of("v1", "v2", "v3"), client1.lists().get("list_k1"));
   }
 
 
   public void testSetPut(DistkvClient client0, DistkvClient client1) {
     Set<String> set = ImmutableSet.of("v1", "v2", "v3");
-    client0.sets().put("k1", set);
-    Assert.assertEquals(set, client0.sets().get("k1"));
-    Assert.assertEquals(set, client1.sets().get("k1"));
+    client0.sets().put("set_k1", set);
+    Assert.assertEquals(set, client0.sets().get("set_k1"));
+    Assert.assertEquals(set, client1.sets().get("set_k1"));
   }
 
 
   public void testDictPut(DistkvClient client0, DistkvClient client1) {
     Map<String, String> dict = new HashMap<>();
-    dict.put("k1", "v1");
+    dict.put("dict_k1", "v1");
     client0.dicts().put("m1", dict);
     Map<String, String> dict1 = client0.dicts().get("m1");
     Assert.assertEquals(dict, dict1);
@@ -93,21 +93,21 @@ public class TestMasterSyncToSlaves {
     list.add(new SortedListEntity("wlll", 8));
     list.add(new SortedListEntity("fw", 9));
     list.add(new SortedListEntity("55", 6));
-    client0.sortedLists().put("k1", list);
+    client0.sortedLists().put("slist_k1", list);
 
-    LinkedList<SortedListEntity> tlist = client0.sortedLists().top("k1", 100);
+    LinkedList<SortedListEntity> tlist = client0.sortedLists().top("slist_k1", 100);
     Assert.assertEquals(tlist.get(0).getMember(), "fw");
     Assert.assertEquals(tlist.get(1).getMember(), "xswl");
 
-    LinkedList<SortedListEntity> tlist1 = client1.sortedLists().top("k1", 100);
+    LinkedList<SortedListEntity> tlist1 = client1.sortedLists().top("slist_k1", 100);
     Assert.assertEquals(tlist1.get(0).getMember(), "fw");
     Assert.assertEquals(tlist1.get(1).getMember(), "xswl");
   }
 
   public void testIntPut(DistkvClient client0, DistkvClient client1)
       throws InvalidProtocolBufferException {
-    client0.ints().put("k1", 1);
-    Assert.assertEquals(1, client0.ints().get("k1"));
-    Assert.assertEquals(1, client1.ints().get("k1"));
+    client0.ints().put("int_k1", 1);
+    Assert.assertEquals(1, client0.ints().get("int_k1"));
+    Assert.assertEquals(1, client1.ints().get("int_k1"));
   }
 }

--- a/test/src/test/java/com/distkv/supplier/BaseTestSupplier.java
+++ b/test/src/test/java/com/distkv/supplier/BaseTestSupplier.java
@@ -7,6 +7,7 @@ import com.distkv.client.DistkvClient;
 import com.distkv.common.utils.RuntimeUtil;
 import com.distkv.server.storeserver.StoreConfig;
 import com.distkv.server.storeserver.StoreServer;
+import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -56,7 +57,9 @@ public class BaseTestSupplier {
       try {
         client[0] = new DefaultDistkvClient(
                 String.format("distkv://127.0.0.1:%d", rpcServerPort.get()));
-        client[0].strs().put("ping", "ping");
+        final String randomStr = RandomStringUtils.random(10);
+        // A dummy put to ping the server is serving.
+        client[0].strs().put(randomStr, randomStr);
         return true;
       } catch (Exception e) {
         return false;
@@ -71,7 +74,9 @@ public class BaseTestSupplier {
       try {
         client[0] = new DefaultAsyncClient(
                 String.format("distkv://127.0.0.1:%d", rpcServerPort.get()));
-        client[0].strs().put("ping", "ping");
+        final String randomStr = RandomStringUtils.random(10);
+        // A dummy put to ping the server is serving.
+        client[0].strs().put(randomStr, randomStr);
         return true;
       } catch (Exception e) {
         return false;


### PR DESCRIPTION
After this PR, the following usage will be broken:
```bash
> str.put k1 v1
> ok
> list.put k1 v2
> errorCode: B000;
 Detail: Error status is class com.distkv.rpc.protobuf.generated.CommonProtocol$Status
```

Before this PR, it's ok to do such thing:
```bash
> str.put k1 v1
> ok
> list.put k1 v2
> ok

> str.get k1
> v1
> list.get k1
> v2
```

This belongs to https://github.com/distkv-project/distkv/issues/602