### PR TITLE
make Wal thread safe

### DIFF
--- a/server/src/main/java/com/distkv/server/storeserver/Wal.java
+++ b/server/src/main/java/com/distkv/server/storeserver/Wal.java
@@ -5,6 +5,7 @@ import com.distkv.core.segment.LogSegment;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * a WAL Implement.
@@ -12,12 +13,19 @@ import java.util.List;
  * The interface for wal is not stable now.  it will change for upper logical.
  */
 public class Wal {
+
   private LogSegment segment = new LogSegment();
   private int lastCommitIndex;
+  private ReentrantLock writeLock = new ReentrantLock();
 
   // this used by follower
   public void append(LogEntry logEntry) {
-    segment.appendLogEntry(logEntry);
+    try {
+      writeLock.lock();
+      segment.appendLogEntry(logEntry);
+    } finally {
+      writeLock.unlock();
+    }
   }
 
   public LogEntry get(int logIndex) {


### PR DESCRIPTION
The append need to protect by lock, but read don't needed. because wal is appened only store, every reading thread read the data from wal with a readed id. so just return the log entery which id is bigger than given readed id.